### PR TITLE
Attempt fixing deploy errors on Heroku

### DIFF
--- a/.streamlit/config.toml
+++ b/.streamlit/config.toml
@@ -1,0 +1,3 @@
+[server]
+headless = true
+enableCORS = false

--- a/Procfile
+++ b/Procfile
@@ -1,1 +1,1 @@
-web: sh setup.sh && streamlit run app2.py
+web: streamlit run app2.py --server.port=$PORT

--- a/setup.sh
+++ b/setup.sh
@@ -1,9 +1,0 @@
-# -*- coding: utf-8 -*-
-
-mkdir -p ~/.streamlit/echo "\
-[server]\n\
-headless = true\n\
-port = $PORT\n\
-enableCORS = false\n\
-\n\
-" > ~/.streamlit/config.toml


### PR DESCRIPTION
This attempts to fix the errors on deploy.
Changes done:
- Removed `setup.sh` script, as it contains errors and only creates config file.
- Created config file `.streamlit/config.toml` with the same options except the server binding port.
- Updated `Procfile` to remove the execution of `setup.sh` and added the required port binding for Heroku.

Hope this helps!